### PR TITLE
New GH Pages hosted qnect.eu

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-qnect.eu
+www.qnect.eu

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+qnect.eu


### PR DESCRIPTION
Making GH Pages use master as root, as the domain name `qnect.eu` is moving to GH Pages.